### PR TITLE
Add support for Razer Blade 15 2022 Advanced

### DIFF
--- a/razer_control_gui/data/devices/laptops.json
+++ b/razer_control_gui/data/devices/laptops.json
@@ -334,5 +334,12 @@
         "pid": "02C7",
         "features": ["logo", "boost", "bho"],
         "fan": [2200, 5000]
+    },
+    {
+        "name": "Razer Blade 2022 Advanced",
+        "vid": "1532",
+        "pid": "028a",
+        "features": ["logo", "boost", "bho"],
+        "fan": [2200, 5000]
     }
 ]


### PR DESCRIPTION
This pull request modifies `laptops.json` to add support for my laptop model. No changes to `udev` rules were needed because its PID already matches one of the entries in the list. There is already an entry in the JSON file for an "early" 2022 Advanced model, so I assume that this is another variant by the manufacturer.

More info:

```sh
> nix-shell -p usbutils --run 'lsusb | grep -i razer'
Bus 001 Device 005: ID 1532:028a Razer USA, Ltd Razer Blade
```