### PR TITLE
feat: enable per_key_rgb for Blade 14 2022 (PID 028c)

### DIFF
--- a/razer_control_gui/data/devices/laptops.json
+++ b/razer_control_gui/data/devices/laptops.json
@@ -262,7 +262,7 @@
         "name": "Blade 14 2022",
         "vid": "1532",
         "pid": "028C",
-        "features": ["logo", "boost", "bho"],
+        "features": ["logo", "boost", "bho", "per_key_rgb"],
         "fan": [3500, 5000]
     },
     {


### PR DESCRIPTION
Added `per_key_rgb` feature flag for Blade 14 2022 (PID 028C).  
I own this specific device and have tested the daemon locally. Sending custom frame HID reports works perfectly and does not trigger the kernel panics mentioned in the source code comments for unsupported devices.