### PR TITLE
Make razer-settings optional to compile and install via install.sh

### DIFF
--- a/razer_control_gui/Cargo.toml
+++ b/razer_control_gui/Cargo.toml
@@ -5,7 +5,9 @@ authors = ["Adrian Kozowski <kontakt@adrian-kozlowski.de>"]
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
+[features]
+default = ["gui"]
+gui = ["dep:gtk4", "dep:libadwaita"]
 
 [[bin]]
 name = "razer-cli"
@@ -18,6 +20,7 @@ path = "src/daemon/daemon.rs"
 [[bin]]
 name = "razer-settings"
 path = "src/razer-settings/razer-settings.rs"
+required-features = ["gui"]
 
 [lints.rust]
 
@@ -37,8 +40,8 @@ systemstat = "0.2.3"
 hidapi = { version = "2.4.1", default-features = false, features = ["linux-native"] }
 serde-big-array = "0.5.1"
 clap = { version = "4.4.13", features = ["derive"] }
-gtk4 = { version = "0.9", features = ["v4_12"] }
-libadwaita = { version = "0.7", features = ["v1_5"] }
+gtk4 = { version = "0.9", features = ["v4_12"], optional = true }
+libadwaita = { version = "0.7", features = ["v1_5"], optional = true }
 glib = "0.20"
 log = "0.4.22"
 env_logger = "0.11.5"

--- a/razer_control_gui/README.md
+++ b/razer_control_gui/README.md
@@ -152,6 +152,8 @@ cd razercontrol-revived/razer_control_gui
 
 # Build and install (will prompt for sudo)
 ./install.sh install
+# Or, only build and install the daemon and cli
+./install.sh install --no-gui
 ```
 
 After installation, **log out and back in** (or reboot) for udev rules to take effect.

--- a/razer_control_gui/install.sh
+++ b/razer_control_gui/install.sh
@@ -12,7 +12,11 @@ detect_init_system() {
 
 install() {
     echo "Building the project..."
-    cargo build --release # TODO: The GUI should be optional. At least for now. Before releasing this, it sould be turned into a feature with an explicit cli switch to install it
+    if [[ "$2" != "--no-gui" ]]; then
+        cargo build --release
+    else
+        cargo build --release --no-default-features
+    fi
 
     if [ $? -ne 0 ]; then
         echo "An error occurred while building the project"
@@ -31,23 +35,34 @@ install() {
     esac
 
     # Install the files
-    echo "Installing the files..."
+    echo "Installing cli and service files..."
     mkdir -p ~/.local/share/razercontrol
     sudo bash <<EOF
         mkdir -p /usr/share/razercontrol
         cp target/release/razer-cli /usr/bin/
-        cp target/release/razer-settings /usr/bin/
-        if ls /usr/share/applications/*.desktop 1> /dev/null 2>&1; then
-            # We only install the desktop file if there are already desktop
-            # files on the system
-            cp data/gui/com.encomjp.razer-settings.desktop /usr/share/applications/
-        fi
-        install -Dm644 data/gui/com.github.encomjp.razercontrol.svg /usr/share/icons/hicolor/scalable/apps/com.github.encomjp.razercontrol.svg
         cp target/release/daemon /usr/bin/razer-daemon
         cp data/devices/laptops.json /usr/share/razercontrol/
         cp data/udev/99-hidraw-permissions.rules /etc/udev/rules.d/
         udevadm control --reload-rules
 EOF
+
+    if [ $? -ne 0 ]; then
+        echo "An error occurred while installing the files"
+        exit 1
+    fi
+
+    if [[ "$2" != "--no-gui" ]]; then
+        echo "Installing gui files..."
+        sudo bash <<EOF
+            cp target/release/razer-settings /usr/bin/
+            if ls /usr/share/applications/*.desktop 1> /dev/null 2>&1; then
+                # We only install the desktop file if there are already desktop
+                # files on the system
+                cp data/gui/com.encomjp.razer-settings.desktop /usr/share/applications/
+            fi
+            install -Dm644 data/gui/com.github.encomjp.razercontrol.svg /usr/share/icons/hicolor/scalable/apps/com.github.encomjp.razercontrol.svg
+EOF
+    fi
 
     if [ $? -ne 0 ]; then
         echo "An error occurred while installing the files"
@@ -131,13 +146,13 @@ main() {
 
     case $1 in
     install)
-        install
+        install $@
         ;;
     uninstall)
         uninstall
         ;;
     *)
-        echo "Usage: $0 {install|uninstall}"
+        echo "Usage: $0 {install|uninstall} [--no-gui]"
         exit 1
         ;;
     esac


### PR DESCRIPTION
Introduces an additional flag to install.sh and a feature to Cargo.toml that allow not installing/building the razer-settings GUI (and the gtk4 and libadwaita dependencies). Strictly as an opt-out, the default is still to compile and install the GUI.